### PR TITLE
feat: Add auto analysis, sign-out, and basic Chrome extension

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,1 +1,9 @@
-{ "manifest_version": 3, "name": "UnsubAI", "version": "1.0", "action": { "default_popup": "popup.html" } }
+{
+  "manifest_version": 3,
+  "name": "UnsubAI",
+  "version": "1.0",
+  "description": "A Chrome extension to complement the UnsubAI web application for managing email subscriptions.",
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,1 +1,15 @@
-<!DOCTYPE html><html><head><title>UnsubAI Login</title></head><body><button>Login with Google</button></body></html>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>UnsubAI Extension</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 200px; padding: 10px; text-align: center; }
+    button { padding: 10px 15px; font-size: 14px; cursor: pointer; width: 100%; }
+  </style>
+</head>
+<body>
+  <h3>UnsubAI</h3>
+  <button id="openWebAppBtn">Open UnsubAI App</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,1 +1,13 @@
-// JS logic to initiate OAuth flow
+document.addEventListener('DOMContentLoaded', function() {
+  const openWebAppBtn = document.getElementById('openWebAppBtn');
+
+  if (openWebAppBtn) {
+    openWebAppBtn.addEventListener('click', function() {
+      // URL of your web application's client
+      const webAppUrl = 'http://localhost:5173';
+      chrome.tabs.create({ url: webAppUrl });
+    });
+  } else {
+    console.error("Button with ID 'openWebAppBtn' not found.");
+  }
+});


### PR DESCRIPTION
This commit introduces several application enhancements:
1.  Automatic Email Analysis on Sign-In:
    - In `client/src/App.jsx`, email analysis now triggers automatically after a successful Google sign-in, improving your workflow.
    - A state flag `initialAnalysisStarted` ensures this only happens once per session/token.
    - Previous analysis results are cleared when a new token is received.

2.  Sign-Out Functionality:
    - Added a "Sign Out" button to `client/src/App.jsx`, visible when you are signed in.
    - Clicking "Sign Out" clears all session-related state (access token, email analysis data, errors), effectively signing you out of the application's client-side session.
    - UI conditionally renders sign-in or sign-out/analysis buttons.

3.  Chrome Extension - Basic Setup (Part 1):
    - Updated `extension/manifest.json` with a description and ensured basic Manifest V3 structure.
    - Redesigned `extension/popup.html` with a clear button to open the main web application.
    - Implemented `extension/popup.js` to handle the button click, opening the web app (`http://localhost:5173`) in a new tab using `chrome.tabs.create()`.

These changes improve the core user experience and lay the groundwork for further Chrome extension development.